### PR TITLE
Initial basic back end in Rust, no external crates

### DIFF
--- a/backend/shigai-serve/Cargo.toml
+++ b/backend/shigai-serve/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "shigai-serve"
+version = "0.1.0"
+authors = ["Patrick O'Melveny <pvomelveny@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/backend/shigai-serve/src/main.rs
+++ b/backend/shigai-serve/src/main.rs
@@ -1,0 +1,130 @@
+use std::io::prelude::{Read, Write};
+use std::net::TcpListener;
+use std::net::TcpStream;
+
+const SRC_ROOT: &str = "../../frontend/src";
+
+fn main() {
+    let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
+
+    for stream in listener.incoming() {
+        let stream = stream.unwrap();
+
+        handle_connection(stream);
+    }
+}
+
+fn handle_connection(mut stream: TcpStream) {
+    let mut buffer = [0; 2048];
+
+    if let Ok(buf_length) = stream.read(&mut buffer) {
+        let message = String::from_utf8_lossy(&buffer[..buf_length]).to_string();
+        println!("{}", message);
+
+        let http_req: http::HTTPRequest = http::process_request(message);
+        router::route(http_req, stream);
+    } else {
+        let response = "HTTP/1.1 400 Bad Request \r\n\r\n";
+
+        stream.write_all(response.as_bytes()).unwrap();
+        stream.flush().unwrap();
+    }
+}
+
+mod router {
+    use crate::http::*;
+    use std::fs;
+    use std::io::prelude::*;
+    use std::net::TcpStream;
+
+    pub fn route(req: HTTPRequest, stream: TcpStream) {
+        match req {
+            HTTPRequest {
+                verb: HTTPVerb::GET,
+                route: rte,
+                ..
+            } if rte == "/" => route_index(stream),
+            HTTPRequest {
+                verb: HTTPVerb::GET,
+                route: rte,
+                ..
+            } => route_general_path(rte, stream),
+            _ => route_error("404", stream),
+        }
+    }
+
+    fn route_index(mut stream: TcpStream) {
+        if let Ok(index) = fs::read_to_string(format!("{}/html/index.html", crate::SRC_ROOT)) {
+            let response = format!("HTTP/1.1 200 OK \r\n\r\n{}", index);
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        } else {
+            route_error("400", stream);
+        }
+
+        println!("ROUTING to index");
+    }
+
+    fn route_general_path(mut route: String, mut stream: TcpStream) {
+        if route.ends_with(".html") {
+            route = format!("/html{}", route);
+        }
+        println!("route: {}", route);
+        if let Ok(contents) = fs::read_to_string(format!("{}{}", crate::SRC_ROOT, route)) {
+            let response = format!("HTTP/1.1 200 OK \r\n\r\n{}", contents);
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        } else {
+            route_error("400", stream);
+        }
+    }
+
+    fn route_error(errcode: &str, mut stream: TcpStream) {
+        let response = format!("HTTP/1.1 {} UnknownResource \r\n\r\n", errcode);
+
+        println!("returning error: {}", errcode);
+        stream.write_all(response.as_bytes()).unwrap();
+        stream.flush().unwrap();
+    }
+}
+
+mod http {
+
+    pub enum HTTPVerb {
+        // This is incomplete, I only remember 3 of them
+        GET,
+        POST,
+        DELETE,
+        UNKNOWN,
+    }
+
+    pub struct HTTPRequest {
+        pub protocol: String,
+        pub verb: HTTPVerb,
+        pub route: String,
+        // who cares about headers
+    }
+
+    pub fn process_request(request: String) -> HTTPRequest {
+        let mut parsed_request = HTTPRequest {
+            protocol: "".to_string(),
+            verb: HTTPVerb::UNKNOWN,
+            route: "".to_string(),
+        };
+
+        let lines: Vec<&str> = request.split("\r\n").collect();
+
+        let fst = lines[0].split(' ').collect::<Vec<&str>>();
+        if let [method, route, protocol] = &fst[..] {
+            parsed_request.route = route.to_string();
+            parsed_request.protocol = protocol.to_string();
+            parsed_request.verb = match method {
+                &"GET" => HTTPVerb::GET,
+                &"POST" => HTTPVerb::POST,
+                &"DELETE" => HTTPVerb::DELETE,
+                _req => HTTPVerb::UNKNOWN,
+            }
+        }
+        parsed_request
+    }
+}

--- a/backend/shigai-serve/src/main.rs
+++ b/backend/shigai-serve/src/main.rs
@@ -61,15 +61,13 @@ mod router {
         } else {
             route_error("400", stream);
         }
-
-        println!("ROUTING to index");
     }
 
     fn route_general_path(mut route: String, mut stream: TcpStream) {
         if route.ends_with(".html") {
             route = format!("/html{}", route);
         }
-        println!("route: {}", route);
+
         if let Ok(contents) = fs::read_to_string(format!("{}{}", crate::SRC_ROOT, route)) {
             let response = format!("HTTP/1.1 200 OK \r\n\r\n{}", contents);
             stream.write_all(response.as_bytes()).unwrap();
@@ -82,7 +80,6 @@ mod router {
     fn route_error(errcode: &str, mut stream: TcpStream) {
         let response = format!("HTTP/1.1 {} UnknownResource \r\n\r\n", errcode);
 
-        println!("returning error: {}", errcode);
         stream.write_all(response.as_bytes()).unwrap();
         stream.flush().unwrap();
     }


### PR DESCRIPTION
Here is a simple, single-threaded back end. Only works locally, so more for testing and illustration. This will let us have a basic idea of how HTML requests work and some basic Rust concepts. 

Next steps are to talk about what sort of libraries to include. At the very least, I vote an HTML processing lib, because that stuff is tedious. 